### PR TITLE
Bugfixes

### DIFF
--- a/constants.hpp
+++ b/constants.hpp
@@ -157,7 +157,7 @@ std::pair<Constant, bool> read_constant(std::ifstream & stream) {
         break;
     case Constant::Type::METHOD_HANDLE:
         // u1u2 method handle (type descriptor and pool index)
-        ref1 = parse<uint8_t>(extract<2>(stream));
+        ref1 = parse<uint8_t>(extract<1>(stream));
         ref2 = parse<uint16_t>(extract<2>(stream));
         value.method_handle = std::pair<uint8_t, uint16_t>(ref1, ref2);
         break;

--- a/types.hpp
+++ b/types.hpp
@@ -199,6 +199,7 @@ std::vector<Type> decode_types(std::string const& internal_type) {
                     current_type = "";
                     break;
                 case 'T':
+                case '*':
                     state = GENERIC_TYPE;
                     break;
                 case 'L':


### PR DESCRIPTION
Fixes a few bugs when reading Class files:
- The method handle constants had 2 instead of 1 byte for the type descriptor
- For generic types only `T` was allowed and not `*`